### PR TITLE
:fire: Removed slash prefix in custom setting paths

### DIFF
--- a/addons/godot_editor_discord_presence/plugin.gd
+++ b/addons/godot_editor_discord_presence/plugin.gd
@@ -19,8 +19,8 @@ const VISUALSCRIPT = "VisualScript"
 const NATIVESCRIPT = "NativeScript"
 const CSHARPSCRIPT = "C# Script"
 
-const FIRST_BUTTON_PATH = "/discord_presence/first_button"
-const SECOND_BUTTON_PATH = "/discord_presence/second_button"
+const FIRST_BUTTON_PATH = "discord_presence/first_button"
+const SECOND_BUTTON_PATH = "discord_presence/second_button"
 
 var _current_script_name: String
 var _current_scene_name: String


### PR DESCRIPTION
The documentation specifies the use of paths to project settings without a slash prefix, see:
https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#method-descriptions

Without this fix, the button settings are reset to default values with the following log messages:

```gdscript
* core/project_settings.cpp:217 - Property not found: discord_presence/first_button/label
* core/project_settings.cpp:217 - Property not found: discord_presence/first_button/url
* core/project_settings.cpp:217 - Property not found: discord_presence/second_button/label
* core/project_settings.cpp:217 - Property not found: discord_presence/second_button/url
```